### PR TITLE
Add .gitattributes to mark generated HTML as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Mark generated Quarto HTML so GitHub Linguist ignores it in language statistics.
+# This prevents rendered HTML (which is generated from .qmd files) from dominating the repository language breakdown.
+*.html linguist-generated=true


### PR DESCRIPTION
The main language for this repo was coming up as HTML because of the rendered HTML files from the R Quarto document(s). Added the .gitattributes file to ignore this when the language is evaluated.